### PR TITLE
Bump version to 0.28.0 for arbitrary depths in ToHtml

### DIFF
--- a/lib/draftjs_html/version.rb
+++ b/lib/draftjs_html/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DraftjsHtml
-  VERSION = "0.27.0"
+  VERSION = "0.28.0"
 end

--- a/spec/draftjs_block_depth_spec.rb
+++ b/spec/draftjs_block_depth_spec.rb
@@ -109,4 +109,26 @@ RSpec.describe DraftjsHtml, 'DraftjsHtml - Block Depth & Nesting' do
       <p></p>
     HTML
   end
+
+  it 'gracefully handles depth when parents are missing' do
+    raw_draftjs = DraftjsHtml::Draftjs::RawBuilder.build do
+      typed_block 'unstyled', 'START'
+      typed_block 'unordered-list-item', 'item 1.1', depth: 1
+      typed_block 'unordered-list-item', 'item 1.2', depth: 2
+      typed_block 'unordered-list-item', 'item 2.0', depth: 1
+      typed_block 'unstyled', 'END'
+    end
+
+    html = described_class.to_html(raw_draftjs)
+
+    expect(html).to eq_ignoring_whitespace <<~HTML.strip
+      <p>START</p>
+      <ul>
+        <li>item 1.1</li>
+        <ul><li>item 1.2</li></ul>
+        <li>item 2.0</li>
+      </ul>
+      <p>END</p>
+    HTML
+  end
 end


### PR DESCRIPTION
This creates 'multi-push' logic for nested lists to handle cases where
draftjs has non-incremental depth jumps. We find this may happen with
copy-pasted content. In this algorithm, we found that if you have a >1
depth jump, `li` elements must be created for the intermediate depth
levels as well as list parents. To maintain the expectations the calling
code has (block is a `li` iteself), we cannot create the final depth list
item. Which is why we finish the method with a dangling push parent.
